### PR TITLE
Refactor#199

### DIFF
--- a/src/main/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolService.java
+++ b/src/main/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolService.java
@@ -226,7 +226,11 @@ public class AfterSchoolService {
             throw new InvalidAfterSchoolUpdateRequestException("수정할 방과후 ID가 필요합니다.");
         }
 
-        if (isSingleUpdate(afterSchoolIds) && requestedPeriod != null && requestedPeriod.isCombined()) {
+        if (requestedPeriod == null){
+            throw new InvalidAfterSchoolUpdateRequestException("period는 필수 입니다.");
+        }
+
+        if (isSingleUpdate(afterSchoolIds) && requestedPeriod.isCombined()) {
             throw new InvalidAfterSchoolUpdateRequestException("8~11교시 수정은 병합된 방과후 ID가 필요합니다.");
         }
 
@@ -240,7 +244,7 @@ public class AfterSchoolService {
     }
 
     private boolean isCombinedUpdate(AfterSchoolUpdatePeriod requestedPeriod) {
-        return requestedPeriod == null || requestedPeriod.isCombined();
+        return requestedPeriod.isCombined();
     }
 
     private Long resolveTargetAfterSchoolId(List<Long> afterSchoolIds, AfterSchoolUpdatePeriod requestedPeriod) {

--- a/src/main/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolService.java
+++ b/src/main/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolService.java
@@ -8,6 +8,7 @@ import solvit.teachmon.domain.after_school.domain.entity.AfterSchoolBusinessTrip
 import solvit.teachmon.domain.after_school.domain.entity.AfterSchoolEntity;
 import solvit.teachmon.domain.after_school.domain.entity.AfterSchoolReinforcementEntity;
 import solvit.teachmon.domain.after_school.domain.entity.AfterSchoolStudentEntity;
+import solvit.teachmon.domain.after_school.domain.enums.AfterSchoolUpdatePeriod;
 import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolBusinessTripRepository;
 import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolReinforcementRepository;
 import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolRepository;
@@ -15,6 +16,7 @@ import solvit.teachmon.domain.after_school.domain.service.AfterSchoolStudentDoma
 import solvit.teachmon.domain.after_school.domain.vo.StudentAssignmentResultVo;
 import solvit.teachmon.domain.after_school.exception.AfterSchoolNotFoundException;
 import solvit.teachmon.domain.after_school.exception.AfterSchoolBusinessTripScheduleNotFoundException;
+import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolInfoException;
 import solvit.teachmon.domain.after_school.exception.PlaceAlreadyBookedException;
 import solvit.teachmon.domain.after_school.presentation.dto.response.*;
 import solvit.teachmon.domain.after_school.presentation.dto.response.StudentInfo;
@@ -110,18 +112,44 @@ public class AfterSchoolService {
 
     @Transactional
     public void updateAfterSchool(AfterSchoolUpdateRequestDto requestDto) {
-        AfterSchoolEntity afterSchool = getAfterSchoolById(requestDto.afterSchoolId());
+        List<Long> afterSchoolIds = requestDto.afterSchoolIds();
+        AfterSchoolUpdatePeriod requestedPeriod = requestDto.requestedPeriod();
+
+        if (afterSchoolIds.isEmpty()) {
+            throw new InvalidAfterSchoolInfoException("수정할 방과후 ID가 필요합니다.");
+        }
+
+        if (afterSchoolIds.size() == 1) {
+            if (requestedPeriod != null && requestedPeriod.isCombined()) {
+                throw new InvalidAfterSchoolInfoException("8~11교시 수정은 병합된 방과후 ID가 필요합니다.");
+            }
+            updateSingleAfterSchool(afterSchoolIds.getFirst(), requestDto, requestedPeriod);
+            return;
+        }
+
+        if (afterSchoolIds.size() != 2) {
+            throw new InvalidAfterSchoolInfoException("병합 방과후 수정은 두 개의 ID만 지원합니다.");
+        }
+
+        updateCombinedAfterSchool(afterSchoolIds, requestDto, requestedPeriod);
+    }
+
+    private void updateSingleAfterSchool(
+            Long afterSchoolId,
+            AfterSchoolUpdateRequestDto requestDto,
+            AfterSchoolUpdatePeriod requestedPeriod
+    ) {
+        AfterSchoolEntity afterSchool = getAfterSchoolById(afterSchoolId);
         supervisionBanDayRepository.deleteAfterSchoolBanDay(afterSchool.getTeacher().getId(), afterSchool.getWeekDay());
 
         TeacherEntity teacher = resolveTeacher(requestDto.teacherId(), afterSchool);
         PlaceEntity place = resolvePlace(requestDto.placeId(), afterSchool);
         WeekDay weekDay = resolveWeekDay(requestDto.weekDay(), afterSchool);
-        SchoolPeriod schoolPeriod = resolveSchoolPeriod(requestDto.period(), afterSchool);
+        SchoolPeriod schoolPeriod = resolveSchoolPeriod(requestedPeriod, afterSchool);
         String name = requestDto.name() != null ? requestDto.name() : afterSchool.getName();
         Integer grade = requestDto.grade() != null ? requestDto.grade() : afterSchool.getGrade();
         Integer year = requestDto.year() != null ? requestDto.year() : afterSchool.getYear();
 
-        // 변경사항이 있는지 확인
         boolean hasChanges = hasAnyChange(teacher, place, weekDay, schoolPeriod, year, name, grade, afterSchool);
 
         afterSchool.updateAfterSchool(
@@ -136,13 +164,12 @@ public class AfterSchoolService {
 
         SupervisionBanDayEntity supervisionBanDayEntity = SupervisionBanDayEntity.builder()
                 .teacher(teacher)
-                .weekDay(requestDto.weekDay())
+                .weekDay(weekDay)
                 .isAfterschool(true)
                 .build();
 
         supervisionBanDayRepository.save(supervisionBanDayEntity);
 
-        // 변경사항이 있고 이번주라면 모든 학생들의 스케줄을 업데이트
         if (hasChanges && isDateInCurrentWeek(LocalDate.now().with(weekDay.toDayOfWeek()))) {
             List<Long> allStudentIds = afterSchool.getAfterSchoolStudents().stream()
                     .map(afterSchoolStudent -> afterSchoolStudent.getStudent().getId())
@@ -157,6 +184,24 @@ public class AfterSchoolService {
         else {
             updateStudentsIfPresent(requestDto.studentsId(), afterSchool);
         }
+    }
+
+    private void updateCombinedAfterSchool(
+            List<Long> afterSchoolIds,
+            AfterSchoolUpdateRequestDto requestDto,
+            AfterSchoolUpdatePeriod requestedPeriod
+    ) {
+        if (requestedPeriod == null || requestedPeriod.isCombined()) {
+            updateSingleAfterSchool(afterSchoolIds.get(0), requestDto, AfterSchoolUpdatePeriod.EIGHT_AND_NINE_PERIOD);
+            updateSingleAfterSchool(afterSchoolIds.get(1), requestDto, AfterSchoolUpdatePeriod.TEN_AND_ELEVEN_PERIOD);
+            return;
+        }
+
+        int targetIndex = requestedPeriod == AfterSchoolUpdatePeriod.TEN_AND_ELEVEN_PERIOD ? 1 : 0;
+        int deleteIndex = targetIndex == 0 ? 1 : 0;
+
+        deleteAfterSchool(afterSchoolIds.get(deleteIndex));
+        updateSingleAfterSchool(afterSchoolIds.get(targetIndex), requestDto, requestedPeriod);
     }
 
     @Transactional
@@ -441,8 +486,8 @@ public class AfterSchoolService {
         return weekDay != null ? weekDay : afterSchool.getWeekDay();
     }
 
-    private SchoolPeriod resolveSchoolPeriod(SchoolPeriod period, AfterSchoolEntity afterSchool) {
-        return period != null ? period : afterSchool.getPeriod();
+    private SchoolPeriod resolveSchoolPeriod(AfterSchoolUpdatePeriod period, AfterSchoolEntity afterSchool) {
+        return period != null ? period.toSchoolPeriod() : afterSchool.getPeriod();
     }
 
     private void updateStudentsIfPresent(List<Long> studentIds, AfterSchoolEntity afterSchool) {

--- a/src/main/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolService.java
+++ b/src/main/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolService.java
@@ -16,7 +16,7 @@ import solvit.teachmon.domain.after_school.domain.service.AfterSchoolStudentDoma
 import solvit.teachmon.domain.after_school.domain.vo.StudentAssignmentResultVo;
 import solvit.teachmon.domain.after_school.exception.AfterSchoolNotFoundException;
 import solvit.teachmon.domain.after_school.exception.AfterSchoolBusinessTripScheduleNotFoundException;
-import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolInfoException;
+import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolUpdateRequestException;
 import solvit.teachmon.domain.after_school.exception.PlaceAlreadyBookedException;
 import solvit.teachmon.domain.after_school.presentation.dto.response.*;
 import solvit.teachmon.domain.after_school.presentation.dto.response.StudentInfo;
@@ -82,7 +82,7 @@ public class AfterSchoolService {
         PlaceEntity place = getPlaceById(requestDto.placeId());
         BranchEntity branch = getBranchByYearAndId(requestDto.year(), requestDto.branch());
         List<StudentEntity> students = fetchStudentsByIds(requestDto.studentsId());
-        
+
         validateStudentsGrade(students, requestDto.grade());
 
         AfterSchoolEntity afterSchool = AfterSchoolEntity.builder()
@@ -97,7 +97,7 @@ public class AfterSchoolService {
                 .build();
 
         afterSchoolRepository.save(afterSchool);
-        
+
         StudentAssignmentResultVo studentAssignmentResultVo = afterSchoolStudentDomainService.assignStudents(afterSchool, students);
         afterSchoolScheduleService.save(List.of(studentAssignmentResultVo));
 
@@ -115,23 +115,19 @@ public class AfterSchoolService {
         List<Long> afterSchoolIds = requestDto.afterSchoolIds();
         AfterSchoolUpdatePeriod requestedPeriod = requestDto.requestedPeriod();
 
-        if (afterSchoolIds.isEmpty()) {
-            throw new InvalidAfterSchoolInfoException("수정할 방과후 ID가 필요합니다.");
-        }
+        validateUpdateRequest(afterSchoolIds, requestedPeriod);
 
-        if (afterSchoolIds.size() == 1) {
-            if (requestedPeriod != null && requestedPeriod.isCombined()) {
-                throw new InvalidAfterSchoolInfoException("8~11교시 수정은 병합된 방과후 ID가 필요합니다.");
-            }
+        if (isSingleUpdate(afterSchoolIds)) {
             updateSingleAfterSchool(afterSchoolIds.getFirst(), requestDto, requestedPeriod);
             return;
         }
 
-        if (afterSchoolIds.size() != 2) {
-            throw new InvalidAfterSchoolInfoException("병합 방과후 수정은 두 개의 ID만 지원합니다.");
+        if (isCombinedUpdate(requestedPeriod)) {
+            updateCombinedAfterSchool(afterSchoolIds, requestDto);
+            return;
         }
 
-        updateCombinedAfterSchool(afterSchoolIds, requestDto, requestedPeriod);
+        shrinkCombinedAfterSchool(afterSchoolIds, requestDto, requestedPeriod);
     }
 
     private void updateSingleAfterSchool(
@@ -174,7 +170,7 @@ public class AfterSchoolService {
             List<Long> allStudentIds = afterSchool.getAfterSchoolStudents().stream()
                     .map(afterSchoolStudent -> afterSchoolStudent.getStudent().getId())
                     .toList();
-            
+
             if (!allStudentIds.isEmpty()) {
                 List<StudentEntity> allStudents = fetchStudentsByIds(allStudentIds);
                 StudentAssignmentResultVo studentAssignmentResultVo = afterSchoolStudentDomainService.assignStudents(afterSchool, allStudents);
@@ -186,26 +182,29 @@ public class AfterSchoolService {
         }
     }
 
-    private void updateCombinedAfterSchool(
+    private void updateCombinedAfterSchool(List<Long> afterSchoolIds, AfterSchoolUpdateRequestDto requestDto) {
+        updateSingleAfterSchool(afterSchoolIds.get(0), requestDto, AfterSchoolUpdatePeriod.EIGHT_AND_NINE_PERIOD);
+        updateSingleAfterSchool(afterSchoolIds.get(1), requestDto, AfterSchoolUpdatePeriod.TEN_AND_ELEVEN_PERIOD);
+    }
+
+    private void shrinkCombinedAfterSchool(
             List<Long> afterSchoolIds,
             AfterSchoolUpdateRequestDto requestDto,
             AfterSchoolUpdatePeriod requestedPeriod
     ) {
-        if (requestedPeriod == null || requestedPeriod.isCombined()) {
-            updateSingleAfterSchool(afterSchoolIds.get(0), requestDto, AfterSchoolUpdatePeriod.EIGHT_AND_NINE_PERIOD);
-            updateSingleAfterSchool(afterSchoolIds.get(1), requestDto, AfterSchoolUpdatePeriod.TEN_AND_ELEVEN_PERIOD);
-            return;
-        }
+        Long targetAfterSchoolId = resolveTargetAfterSchoolId(afterSchoolIds, requestedPeriod);
+        Long deleteAfterSchoolId = resolveDeleteAfterSchoolId(afterSchoolIds, requestedPeriod);
 
-        int targetIndex = requestedPeriod == AfterSchoolUpdatePeriod.TEN_AND_ELEVEN_PERIOD ? 1 : 0;
-        int deleteIndex = targetIndex == 0 ? 1 : 0;
-
-        deleteAfterSchool(afterSchoolIds.get(deleteIndex));
-        updateSingleAfterSchool(afterSchoolIds.get(targetIndex), requestDto, requestedPeriod);
+        deleteAfterSchoolInternal(deleteAfterSchoolId);
+        updateSingleAfterSchool(targetAfterSchoolId, requestDto, requestedPeriod);
     }
 
     @Transactional
     public void deleteAfterSchool(Long afterSchoolId) {
+        deleteAfterSchoolInternal(afterSchoolId);
+    }
+
+    private void deleteAfterSchoolInternal(Long afterSchoolId) {
         AfterSchoolEntity afterSchool = afterSchoolRepository.findById(afterSchoolId)
                 .orElseThrow(() -> new AfterSchoolNotFoundException(afterSchoolId));
 
@@ -220,6 +219,40 @@ public class AfterSchoolService {
         }
 
         afterSchoolRepository.delete(afterSchool);
+    }
+
+    private void validateUpdateRequest(List<Long> afterSchoolIds, AfterSchoolUpdatePeriod requestedPeriod) {
+        if (afterSchoolIds.isEmpty()) {
+            throw new InvalidAfterSchoolUpdateRequestException("수정할 방과후 ID가 필요합니다.");
+        }
+
+        if (isSingleUpdate(afterSchoolIds) && requestedPeriod != null && requestedPeriod.isCombined()) {
+            throw new InvalidAfterSchoolUpdateRequestException("8~11교시 수정은 병합된 방과후 ID가 필요합니다.");
+        }
+
+        if (!isSingleUpdate(afterSchoolIds) && afterSchoolIds.size() != 2) {
+            throw new InvalidAfterSchoolUpdateRequestException("병합 방과후 수정은 두 개의 ID만 지원합니다.");
+        }
+    }
+
+    private boolean isSingleUpdate(List<Long> afterSchoolIds) {
+        return afterSchoolIds.size() == 1;
+    }
+
+    private boolean isCombinedUpdate(AfterSchoolUpdatePeriod requestedPeriod) {
+        return requestedPeriod == null || requestedPeriod.isCombined();
+    }
+
+    private Long resolveTargetAfterSchoolId(List<Long> afterSchoolIds, AfterSchoolUpdatePeriod requestedPeriod) {
+        return requestedPeriod == AfterSchoolUpdatePeriod.TEN_AND_ELEVEN_PERIOD
+                ? afterSchoolIds.get(1)
+                : afterSchoolIds.get(0);
+    }
+
+    private Long resolveDeleteAfterSchoolId(List<Long> afterSchoolIds, AfterSchoolUpdatePeriod requestedPeriod) {
+        return requestedPeriod == AfterSchoolUpdatePeriod.TEN_AND_ELEVEN_PERIOD
+                ? afterSchoolIds.get(0)
+                : afterSchoolIds.get(1);
     }
 
     @Transactional

--- a/src/main/java/solvit/teachmon/domain/after_school/domain/enums/AfterSchoolUpdatePeriod.java
+++ b/src/main/java/solvit/teachmon/domain/after_school/domain/enums/AfterSchoolUpdatePeriod.java
@@ -1,6 +1,6 @@
 package solvit.teachmon.domain.after_school.domain.enums;
 
-import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolInfoException;
+import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolUpdateRequestException;
 import solvit.teachmon.global.enums.SchoolPeriod;
 
 import java.util.Locale;
@@ -25,7 +25,7 @@ public enum AfterSchoolUpdatePeriod {
             case "EIGHT_AND_NINE_PERIOD", "8~9교시" -> EIGHT_AND_NINE_PERIOD;
             case "TEN_AND_ELEVEN_PERIOD", "10~11교시" -> TEN_AND_ELEVEN_PERIOD;
             case "EIGHT_TO_ELEVEN_PERIOD", "EIGHT_TO_ELEVEN", "8~11교시" -> EIGHT_TO_ELEVEN_PERIOD;
-            default -> throw new InvalidAfterSchoolInfoException("유효하지 않은 방과후 교시 요청입니다: " + value);
+            default -> throw new InvalidAfterSchoolUpdateRequestException("유효하지 않은 방과후 교시 요청입니다: " + value);
         };
     }
 
@@ -35,7 +35,7 @@ public enum AfterSchoolUpdatePeriod {
 
     public SchoolPeriod toSchoolPeriod() {
         if (schoolPeriod == null) {
-            throw new InvalidAfterSchoolInfoException("8~11교시는 단일 방과후 교시로 저장할 수 없습니다.");
+            throw new InvalidAfterSchoolUpdateRequestException("8~11교시는 단일 방과후 교시로 저장할 수 없습니다.");
         }
         return schoolPeriod;
     }

--- a/src/main/java/solvit/teachmon/domain/after_school/domain/enums/AfterSchoolUpdatePeriod.java
+++ b/src/main/java/solvit/teachmon/domain/after_school/domain/enums/AfterSchoolUpdatePeriod.java
@@ -1,0 +1,42 @@
+package solvit.teachmon.domain.after_school.domain.enums;
+
+import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolInfoException;
+import solvit.teachmon.global.enums.SchoolPeriod;
+
+import java.util.Locale;
+
+public enum AfterSchoolUpdatePeriod {
+    EIGHT_AND_NINE_PERIOD(SchoolPeriod.EIGHT_AND_NINE_PERIOD),
+    TEN_AND_ELEVEN_PERIOD(SchoolPeriod.TEN_AND_ELEVEN_PERIOD),
+    EIGHT_TO_ELEVEN_PERIOD(null);
+
+    private final SchoolPeriod schoolPeriod;
+
+    AfterSchoolUpdatePeriod(SchoolPeriod schoolPeriod) {
+        this.schoolPeriod = schoolPeriod;
+    }
+
+    public static AfterSchoolUpdatePeriod from(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return switch (value.trim().toUpperCase(Locale.ROOT)) {
+            case "EIGHT_AND_NINE_PERIOD", "8~9교시" -> EIGHT_AND_NINE_PERIOD;
+            case "TEN_AND_ELEVEN_PERIOD", "10~11교시" -> TEN_AND_ELEVEN_PERIOD;
+            case "EIGHT_TO_ELEVEN_PERIOD", "EIGHT_TO_ELEVEN", "8~11교시" -> EIGHT_TO_ELEVEN_PERIOD;
+            default -> throw new InvalidAfterSchoolInfoException("유효하지 않은 방과후 교시 요청입니다: " + value);
+        };
+    }
+
+    public boolean isCombined() {
+        return this == EIGHT_TO_ELEVEN_PERIOD;
+    }
+
+    public SchoolPeriod toSchoolPeriod() {
+        if (schoolPeriod == null) {
+            throw new InvalidAfterSchoolInfoException("8~11교시는 단일 방과후 교시로 저장할 수 없습니다.");
+        }
+        return schoolPeriod;
+    }
+}

--- a/src/main/java/solvit/teachmon/domain/after_school/exception/InvalidAfterSchoolUpdateRequestException.java
+++ b/src/main/java/solvit/teachmon/domain/after_school/exception/InvalidAfterSchoolUpdateRequestException.java
@@ -1,0 +1,10 @@
+package solvit.teachmon.domain.after_school.exception;
+
+import org.springframework.http.HttpStatus;
+import solvit.teachmon.global.exception.TeachmonBusinessException;
+
+public class InvalidAfterSchoolUpdateRequestException extends TeachmonBusinessException {
+    public InvalidAfterSchoolUpdateRequestException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/solvit/teachmon/domain/after_school/presentation/dto/request/AfterSchoolUpdateRequestDto.java
+++ b/src/main/java/solvit/teachmon/domain/after_school/presentation/dto/request/AfterSchoolUpdateRequestDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import solvit.teachmon.domain.after_school.domain.enums.AfterSchoolUpdatePeriod;
-import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolInfoException;
+import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolUpdateRequestException;
 import solvit.teachmon.global.enums.WeekDay;
 
 import java.util.Arrays;
@@ -48,7 +48,7 @@ public record AfterSchoolUpdateRequestDto(
                     .map(Long::parseLong)
                     .toList();
         } catch (NumberFormatException exception) {
-            throw new InvalidAfterSchoolInfoException("after_school_id 형식이 올바르지 않습니다: " + afterSchoolId);
+            throw new InvalidAfterSchoolUpdateRequestException("after_school_id 형식이 올바르지 않습니다: " + afterSchoolId);
         }
     }
 

--- a/src/main/java/solvit/teachmon/domain/after_school/presentation/dto/request/AfterSchoolUpdateRequestDto.java
+++ b/src/main/java/solvit/teachmon/domain/after_school/presentation/dto/request/AfterSchoolUpdateRequestDto.java
@@ -4,15 +4,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import solvit.teachmon.global.enums.SchoolPeriod;
+import solvit.teachmon.domain.after_school.domain.enums.AfterSchoolUpdatePeriod;
+import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolInfoException;
 import solvit.teachmon.global.enums.WeekDay;
 
+import java.util.Arrays;
 import java.util.List;
 
 public record AfterSchoolUpdateRequestDto(
         @JsonProperty("after_school_id")
         @NotNull(message = "방과후 수정 요청에서 after_school_id는 필수입니다.")
-        Long afterSchoolId,
+        String afterSchoolId,
 
         @Min(value = 2000, message = "연도는 2000년 이상이어야 합니다.")
         @Max(value = 2100, message = "연도는 2100년 이하여야 합니다.")
@@ -25,7 +27,7 @@ public record AfterSchoolUpdateRequestDto(
         @JsonProperty("week_day")
         WeekDay weekDay,
 
-        SchoolPeriod period,
+        String period,
 
         @JsonProperty("teacher_id")
         Long teacherId,
@@ -38,4 +40,19 @@ public record AfterSchoolUpdateRequestDto(
         @JsonProperty("students_id")
         List<Long> studentsId
 ) {
+    public List<Long> afterSchoolIds() {
+        try {
+            return Arrays.stream(afterSchoolId.split(","))
+                    .map(String::trim)
+                    .filter(value -> !value.isEmpty())
+                    .map(Long::parseLong)
+                    .toList();
+        } catch (NumberFormatException exception) {
+            throw new InvalidAfterSchoolInfoException("after_school_id 형식이 올바르지 않습니다: " + afterSchoolId);
+        }
+    }
+
+    public AfterSchoolUpdatePeriod requestedPeriod() {
+        return AfterSchoolUpdatePeriod.from(period);
+    }
 }

--- a/src/test/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolServiceBanDayTest.java
+++ b/src/test/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolServiceBanDayTest.java
@@ -137,11 +137,11 @@ class AfterSchoolServiceBanDayTest {
         given(placeRepository.findById(3L)).willReturn(Optional.of(newPlace));
 
         AfterSchoolUpdateRequestDto request = new AfterSchoolUpdateRequestDto(
-                1L,
+                "1",
                 2024,
                 1,
                 WeekDay.TUE,
-                SchoolPeriod.EIGHT_AND_NINE_PERIOD,
+                "EIGHT_AND_NINE_PERIOD",
                 2L,
                 3L,
                 "New",

--- a/src/test/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolServiceUpdateFlowTest.java
+++ b/src/test/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolServiceUpdateFlowTest.java
@@ -14,7 +14,7 @@ import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolBusiness
 import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolReinforcementRepository;
 import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolRepository;
 import solvit.teachmon.domain.after_school.domain.service.AfterSchoolStudentDomainService;
-import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolInfoException;
+import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolUpdateRequestException;
 import solvit.teachmon.domain.after_school.presentation.dto.request.AfterSchoolUpdateRequestDto;
 import solvit.teachmon.domain.branch.domain.repository.BranchRepository;
 import solvit.teachmon.domain.management.teacher.domain.repository.SupervisionBanDayRepository;
@@ -232,7 +232,7 @@ class AfterSchoolServiceUpdateFlowTest {
         );
 
         assertThatThrownBy(() -> afterSchoolService.updateAfterSchool(request))
-                .isInstanceOf(InvalidAfterSchoolInfoException.class)
+                .isInstanceOf(InvalidAfterSchoolUpdateRequestException.class)
                 .hasMessageContaining("병합된 방과후 ID");
 
         verify(afterSchoolRepository, never()).findWithAllRelations(anyLong());

--- a/src/test/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolServiceUpdateFlowTest.java
+++ b/src/test/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolServiceUpdateFlowTest.java
@@ -1,0 +1,273 @@
+package solvit.teachmon.domain.after_school.application.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import solvit.teachmon.domain.after_school.domain.entity.AfterSchoolEntity;
+import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolBusinessTripRepository;
+import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolReinforcementRepository;
+import solvit.teachmon.domain.after_school.domain.repository.AfterSchoolRepository;
+import solvit.teachmon.domain.after_school.domain.service.AfterSchoolStudentDomainService;
+import solvit.teachmon.domain.after_school.exception.InvalidAfterSchoolInfoException;
+import solvit.teachmon.domain.after_school.presentation.dto.request.AfterSchoolUpdateRequestDto;
+import solvit.teachmon.domain.branch.domain.repository.BranchRepository;
+import solvit.teachmon.domain.management.teacher.domain.repository.SupervisionBanDayRepository;
+import solvit.teachmon.domain.management.student.domain.repository.StudentRepository;
+import solvit.teachmon.domain.place.domain.entity.PlaceEntity;
+import solvit.teachmon.domain.place.domain.repository.PlaceRepository;
+import solvit.teachmon.domain.student_schedule.domain.repository.ScheduleRepository;
+import solvit.teachmon.domain.student_schedule.domain.repository.StudentScheduleRepository;
+import solvit.teachmon.domain.student_schedule.domain.repository.schedules.AfterSchoolScheduleRepository;
+import solvit.teachmon.domain.user.domain.entity.TeacherEntity;
+import solvit.teachmon.domain.user.domain.repository.TeacherRepository;
+import solvit.teachmon.global.enums.SchoolPeriod;
+import solvit.teachmon.global.enums.WeekDay;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("방과후 수정 분기 테스트")
+class AfterSchoolServiceUpdateFlowTest {
+
+    @Mock
+    private AfterSchoolStudentDomainService afterSchoolStudentDomainService;
+    @Mock
+    private SupervisionBanDayRepository supervisionBanDayRepository;
+    @Mock
+    private AfterSchoolRepository afterSchoolRepository;
+    @Mock
+    private AfterSchoolBusinessTripRepository afterSchoolBusinessTripRepository;
+    @Mock
+    private AfterSchoolReinforcementRepository afterSchoolReinforcementRepository;
+    @Mock
+    private TeacherRepository teacherRepository;
+    @Mock
+    private StudentRepository studentRepository;
+    @Mock
+    private BranchRepository branchRepository;
+    @Mock
+    private PlaceRepository placeRepository;
+    @Mock
+    private StudentScheduleRepository studentScheduleRepository;
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
+    private AfterSchoolScheduleService afterSchoolScheduleService;
+    @Mock
+    private AfterSchoolScheduleRepository afterSchoolScheduleRepository;
+
+    private AfterSchoolService afterSchoolService;
+
+    @BeforeEach
+    void setUp() {
+        afterSchoolService = new AfterSchoolService(
+                afterSchoolStudentDomainService,
+                supervisionBanDayRepository,
+                afterSchoolRepository,
+                afterSchoolBusinessTripRepository,
+                afterSchoolReinforcementRepository,
+                teacherRepository,
+                studentRepository,
+                branchRepository,
+                placeRepository,
+                studentScheduleRepository,
+                scheduleRepository,
+                afterSchoolScheduleService,
+                afterSchoolScheduleRepository
+        );
+    }
+
+    @Test
+    @DisplayName("단일 ID 수정은 기존 로직대로 처리한다")
+    void updateSingleAfterSchool() {
+        TeacherEntity originalTeacher = mockTeacher(10L);
+        TeacherEntity newTeacher = mockTeacher(20L);
+        PlaceEntity currentPlace = mockPlace(30L);
+        PlaceEntity newPlace = mockPlace(40L);
+        AfterSchoolEntity afterSchool = mockAfterSchool(originalTeacher, currentPlace, WeekDay.MON, SchoolPeriod.EIGHT_AND_NINE_PERIOD, 2026, "기존 방과후", 2);
+
+        given(afterSchoolRepository.findWithAllRelations(1L)).willReturn(Optional.of(afterSchool));
+        given(teacherRepository.findById(20L)).willReturn(Optional.of(newTeacher));
+        given(placeRepository.findById(40L)).willReturn(Optional.of(newPlace));
+
+        AfterSchoolUpdateRequestDto request = new AfterSchoolUpdateRequestDto(
+                "1",
+                2026,
+                2,
+                WeekDay.TUE,
+                "EIGHT_AND_NINE_PERIOD",
+                20L,
+                40L,
+                "수정 방과후",
+                null
+        );
+
+        afterSchoolService.updateAfterSchool(request);
+
+        verify(afterSchool).updateAfterSchool(
+                newTeacher,
+                newPlace,
+                WeekDay.TUE,
+                SchoolPeriod.EIGHT_AND_NINE_PERIOD,
+                2026,
+                "수정 방과후",
+                2
+        );
+    }
+
+    @Test
+    @DisplayName("병합 ID와 8~11교시 요청이면 두 방과후를 각각 수정한다")
+    void updateCombinedAfterSchoolToCombinedPeriod() {
+        TeacherEntity teacher = mockTeacher(10L);
+        PlaceEntity place = mockPlace(30L);
+        AfterSchoolEntity eightNine = mockAfterSchool(teacher, place, WeekDay.MON, SchoolPeriod.EIGHT_AND_NINE_PERIOD, 2026, "방과후", 2);
+        AfterSchoolEntity tenEleven = mockAfterSchool(teacher, place, WeekDay.MON, SchoolPeriod.TEN_AND_ELEVEN_PERIOD, 2026, "방과후", 2);
+
+        given(afterSchoolRepository.findWithAllRelations(1L)).willReturn(Optional.of(eightNine));
+        given(afterSchoolRepository.findWithAllRelations(2L)).willReturn(Optional.of(tenEleven));
+
+        AfterSchoolUpdateRequestDto request = new AfterSchoolUpdateRequestDto(
+                "1,2",
+                2026,
+                2,
+                WeekDay.MON,
+                "EIGHT_TO_ELEVEN_PERIOD",
+                null,
+                null,
+                "통합 방과후",
+                null
+        );
+
+        afterSchoolService.updateAfterSchool(request);
+
+        verify(eightNine).updateAfterSchool(
+                teacher,
+                place,
+                WeekDay.MON,
+                SchoolPeriod.EIGHT_AND_NINE_PERIOD,
+                2026,
+                "통합 방과후",
+                2
+        );
+        verify(tenEleven).updateAfterSchool(
+                teacher,
+                place,
+                WeekDay.MON,
+                SchoolPeriod.TEN_AND_ELEVEN_PERIOD,
+                2026,
+                "통합 방과후",
+                2
+        );
+        verify(afterSchoolRepository, never()).delete(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("병합 ID를 8~9교시로 축소하면 10~11교시를 먼저 삭제한 뒤 8~9교시를 수정한다")
+    void shrinkCombinedAfterSchoolToEightNinePeriod() {
+        TeacherEntity teacher = mockTeacher(10L);
+        PlaceEntity place = mockPlace(30L);
+        AfterSchoolEntity eightNine = mockAfterSchool(teacher, place, WeekDay.MON, SchoolPeriod.EIGHT_AND_NINE_PERIOD, 2026, "방과후", 2);
+        AfterSchoolEntity tenEleven = mockAfterSchool(teacher, place, WeekDay.MON, SchoolPeriod.TEN_AND_ELEVEN_PERIOD, 2026, "방과후", 2);
+
+        given(afterSchoolRepository.findWithAllRelations(1L)).willReturn(Optional.of(eightNine));
+        given(afterSchoolRepository.findById(2L)).willReturn(Optional.of(tenEleven));
+        given(afterSchoolScheduleRepository.findScheduleIdsByAfterSchoolId(2L)).willReturn(List.of());
+
+        AfterSchoolUpdateRequestDto request = new AfterSchoolUpdateRequestDto(
+                "1,2",
+                2026,
+                2,
+                WeekDay.TUE,
+                "EIGHT_AND_NINE_PERIOD",
+                null,
+                null,
+                "축소 방과후",
+                null
+        );
+
+        afterSchoolService.updateAfterSchool(request);
+
+        InOrder inOrder = inOrder(afterSchoolRepository, eightNine);
+        inOrder.verify(afterSchoolRepository).delete(tenEleven);
+        inOrder.verify(eightNine).updateAfterSchool(
+                teacher,
+                place,
+                WeekDay.TUE,
+                SchoolPeriod.EIGHT_AND_NINE_PERIOD,
+                2026,
+                "축소 방과후",
+                2
+        );
+    }
+
+    @Test
+    @DisplayName("단일 ID에 8~11교시 요청이 들어오면 예외가 발생한다")
+    void rejectCombinedPeriodForSingleId() {
+        AfterSchoolUpdateRequestDto request = new AfterSchoolUpdateRequestDto(
+                "1",
+                2026,
+                2,
+                WeekDay.MON,
+                "EIGHT_TO_ELEVEN_PERIOD",
+                null,
+                null,
+                "잘못된 요청",
+                null
+        );
+
+        assertThatThrownBy(() -> afterSchoolService.updateAfterSchool(request))
+                .isInstanceOf(InvalidAfterSchoolInfoException.class)
+                .hasMessageContaining("병합된 방과후 ID");
+
+        verify(afterSchoolRepository, never()).findWithAllRelations(anyLong());
+    }
+
+    private TeacherEntity mockTeacher(Long id) {
+        TeacherEntity teacher = mock(TeacherEntity.class);
+        given(teacher.getId()).willReturn(id);
+        return teacher;
+    }
+
+    private PlaceEntity mockPlace(Long id) {
+        PlaceEntity place = mock(PlaceEntity.class);
+        given(place.getId()).willReturn(id);
+        return place;
+    }
+
+    private AfterSchoolEntity mockAfterSchool(
+            TeacherEntity teacher,
+            PlaceEntity place,
+            WeekDay weekDay,
+            SchoolPeriod period,
+            Integer year,
+            String name,
+            Integer grade
+    ) {
+        AfterSchoolEntity afterSchool = mock(AfterSchoolEntity.class);
+        given(afterSchool.getTeacher()).willReturn(teacher);
+        given(afterSchool.getPlace()).willReturn(place);
+        given(afterSchool.getWeekDay()).willReturn(weekDay);
+        given(afterSchool.getPeriod()).willReturn(period);
+        given(afterSchool.getYear()).willReturn(year);
+        given(afterSchool.getName()).willReturn(name);
+        given(afterSchool.getGrade()).willReturn(grade);
+        given(afterSchool.getAfterSchoolStudents()).willReturn(List.of());
+        return afterSchool;
+    }
+}

--- a/src/test/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolServiceUpdateFlowTest.java
+++ b/src/test/java/solvit/teachmon/domain/after_school/application/service/AfterSchoolServiceUpdateFlowTest.java
@@ -178,6 +178,28 @@ class AfterSchoolServiceUpdateFlowTest {
     }
 
     @Test
+    @DisplayName("병합 ID에 period가 null이면 예외가 발생한다")
+    void rejectNullPeriodForCombinedUpdate() {
+        AfterSchoolUpdateRequestDto request = new AfterSchoolUpdateRequestDto(
+                "1,2",
+                2026,
+                2,
+                WeekDay.MON,
+                null,
+                null,
+                null,
+                "주기 미변경 방과후",
+                null
+        );
+
+        assertThatThrownBy(() -> afterSchoolService.updateAfterSchool(request))
+                .isInstanceOf(InvalidAfterSchoolUpdateRequestException.class)
+                .hasMessageContaining("period는 필수");
+
+        verify(afterSchoolRepository, never()).findWithAllRelations(anyLong());
+    }
+
+    @Test
     @DisplayName("병합 ID를 8~9교시로 축소하면 10~11교시를 먼저 삭제한 뒤 8~9교시를 수정한다")
     void shrinkCombinedAfterSchoolToEightNinePeriod() {
         TeacherEntity teacher = mockTeacher(10L);

--- a/src/test/java/solvit/teachmon/domain/after_school/presentation/controller/AfterSchoolControllerTest.java
+++ b/src/test/java/solvit/teachmon/domain/after_school/presentation/controller/AfterSchoolControllerTest.java
@@ -67,11 +67,11 @@ class AfterSchoolControllerTest {
     @DisplayName("방과후 수정 시 200 상태코드를 반환한다")
     void shouldUpdateAfterSchoolSuccessfully() {
         AfterSchoolUpdateRequestDto request = new AfterSchoolUpdateRequestDto(
-                1L,
+                "1",
                 2024,
                 3,
                 WeekDay.TUE,
-                SchoolPeriod.EIGHT_AND_NINE_PERIOD,
+                "EIGHT_AND_NINE_PERIOD",
                 2L,
                 2L,
                 "웹 개발 기초",
@@ -89,11 +89,11 @@ class AfterSchoolControllerTest {
     @DisplayName("존재하지 않는 방과후 수정 시 예외가 발생한다")
     void shouldThrowExceptionWhenAfterSchoolNotFoundInUpdate() {
         AfterSchoolUpdateRequestDto request = new AfterSchoolUpdateRequestDto(
-                999L,
+                "999",
                 2024,
                 2,
                 WeekDay.MON,
-                SchoolPeriod.EIGHT_AND_NINE_PERIOD,
+                "EIGHT_AND_NINE_PERIOD",
                 1L,
                 1L,
                 "정보처리 산업기사 Java",


### PR DESCRIPTION
close #199 

<img width="617" height="270" alt="image" src="https://github.com/user-attachments/assets/3fe2b900-e80b-4378-8dbc-428d2209d7d7" />


updateRequset DTO 수정 
after_school_id → Long에서 String으로 수정하여 아래와 같이 받을 수 있도록 수정함
”id1,id2”(두개 수정) , “id1”(단일 수정)
또한 
period → enum에서 String으로 수정함. 
기존 처럼 EIGHT_AND_NINE_PERIOD 이렇게 또는 8~9교시 이렇게 요청해도 됨.
from 메소드를 통해 매핑 하도록 만듦.

추가 메서드
afterSchoolIds() → “id1,id2” → List<Long>
requestedPeriod() → 문자열을 enum으로 파싱하는 함수

수정 요청을 다루기 위한 enum 추가
기존 8 ~ 9,10 ~ 11은 기존의 SchoolPeriod와 매칭되도록 했고, 8~11교시를 받을 수 있도록 하였음

update 로직 분기 추가
id 한개인 경우 → 기존 로직대로 처리
id 두개 및 8 ~ 11교시 → 첫번째 id 8 ~ 9교시, 두번째 id 10 ~ 11교시
id 두개 및 (8 ~ 9교시) → 첫번째 id 수정 및 두번째 id 삭제
id 두개 및 (10 ~ 11교시) → 첫번재 id 삭제 및 두번째 id 수정
→ 감독 금지 요일에서 수정 후 금지 요일을 수정하는데, 수정 후 삭제시 수정 된 금지 요일이 삭제 되어서 이렇게 처리함.